### PR TITLE
Replace empty embed field arrays with null after serialization

### DIFF
--- a/deck-common/src/main/kotlin/io/github/deck/common/entity/Messages.kt
+++ b/deck-common/src/main/kotlin/io/github/deck/common/entity/Messages.kt
@@ -57,7 +57,7 @@ public data class RawEmbed(
     val image: OptionalProperty<RawEmbedImage> = OptionalProperty.NotPresent,
     val thumbnail: OptionalProperty<RawEmbedImage> = OptionalProperty.NotPresent,
     val author: OptionalProperty<RawEmbedAuthor> = OptionalProperty.NotPresent,
-    val fields: OptionalProperty<List<RawEmbedField>> = OptionalProperty.NotPresent
+    val fields: OptionalProperty<List<RawEmbedField>> = OptionalProperty.Present(emptyList())
 )
 
 @Serializable

--- a/deck-rest/src/main/kotlin/io/github/deck/rest/builder/ChannelBuilders.kt
+++ b/deck-rest/src/main/kotlin/io/github/deck/rest/builder/ChannelBuilders.kt
@@ -2,11 +2,9 @@ package io.github.deck.rest.builder
 
 import io.github.deck.common.Embed
 import io.github.deck.common.EmbedBuilder
+import io.github.deck.common.entity.RawEmbed
 import io.github.deck.common.entity.RawServerChannelType
-import io.github.deck.common.util.GenericId
-import io.github.deck.common.util.IntGenericId
-import io.github.deck.common.util.nullableOptional
-import io.github.deck.common.util.optional
+import io.github.deck.common.util.*
 import io.github.deck.rest.request.*
 import io.github.deck.rest.util.required
 import kotlinx.datetime.Instant
@@ -21,15 +19,14 @@ import kotlin.time.Duration.Companion.minutes
 public class CreateChannelRequestBuilder: RequestBuilder<CreateChannelRequest> {
     public var name: String by required()
     public var topic: String? = null
-
     public var type: RawServerChannelType by required()
-    public var isPublic: Boolean = false
 
+    public var isPublic: Boolean = false
     // You must choose at least one of those to provide
     public var serverId: GenericId? = null
+
     public var groupId: GenericId? = null
     public var categoryId: IntGenericId? = null
-
     override fun toRequest(): CreateChannelRequest = CreateChannelRequest(
         name = name.optional(),
         topic = topic.nullableOptional(),
@@ -39,22 +36,22 @@ public class CreateChannelRequestBuilder: RequestBuilder<CreateChannelRequest> {
         groupId = groupId.nullableOptional(),
         categoryId = categoryId.nullableOptional()
     )
+
 }
 
 public class SendMessageRequestBuilder: RequestBuilder<SendMessageRequest> {
     public var isPrivate: Boolean = false
     public val repliesTo: MutableList<UUID> = mutableListOf()
-
     public var content: String?
         set(value) {
             contentElement = if (value == null) null else JsonPrimitive(value)
         }
         get() = contentElement?.jsonPrimitive?.content
+
     public var contentElement: JsonElement? = null
-
     public var embeds: List<Embed> = listOf()
-    public val silent: Boolean = false
 
+    public val silent: Boolean = false
     public fun replyTo(vararg messageIds: UUID): Unit =
         repliesTo.addAll(messageIds).let {}
 
@@ -64,11 +61,12 @@ public class SendMessageRequestBuilder: RequestBuilder<SendMessageRequest> {
 
     override fun toRequest(): SendMessageRequest = SendMessageRequest(
         content = contentElement,
-        embeds = embeds.map { it.toSerializable() },
+        embeds = embeds.map { formatAndSerializeEmbed(it) },
         isPrivate = isPrivate,
         isSilent = silent,
         replyMessageIds = repliesTo
     )
+
 }
 
 public class UpdateMessageRequestBuilder: RequestBuilder<UpdateMessageRequest> {
@@ -79,35 +77,35 @@ public class UpdateMessageRequestBuilder: RequestBuilder<UpdateMessageRequest> {
         get() = contentElement?.jsonPrimitive?.content
     public var contentElement: JsonElement? = null
     public var embeds: List<Embed> = listOf()
-
     public fun embed(builder: EmbedBuilder.() -> Unit) {
         embeds = embeds + EmbedBuilder().apply(builder).build()
     }
 
     override fun toRequest(): UpdateMessageRequest = UpdateMessageRequest(
         content = contentElement,
-        embeds = embeds.map { it.toSerializable() },
+        embeds = embeds.map { formatAndSerializeEmbed(it) },
     )
+
 }
 
 public class CreateDocumentationRequestBuilder: RequestBuilder<CreateDocumentationRequest> {
     public var title: String by required()
     public var content: String by required()
-
     override fun toRequest(): CreateDocumentationRequest = CreateDocumentationRequest(
         title = title,
         content = content
     )
+
 }
 
 public class CreateListItemRequestBuilder: RequestBuilder<CreateListItemRequest> {
     public var label: String by required()
     public var note: String? = null
-
     override fun toRequest(): CreateListItemRequest = CreateListItemRequest(
         message = label,
         note = note?.let { JsonObject(mapOf("content" to JsonPrimitive(note))) }.nullableOptional()
     )
+
 }
 
 public typealias UpdateListItemRequestBuilder = CreateListItemRequestBuilder
@@ -115,35 +113,34 @@ public typealias UpdateListItemRequestBuilder = CreateListItemRequestBuilder
 public class CreateForumTopicRequestBuilder: RequestBuilder<CreateForumTopicRequest> {
     public var title: String by required()
     public var content: String by required()
-
     override fun toRequest(): CreateForumTopicRequest = CreateForumTopicRequest(
         title = title,
         content = content
     )
+
 }
 
 public class UpdateForumTopicRequestBuilder: RequestBuilder<UpdateForumTopicRequest> {
     public var title: String? = null
     public var content: String? = null
-
     override fun toRequest(): UpdateForumTopicRequest = UpdateForumTopicRequest(
         title = title.nullableOptional(),
         content = content.nullableOptional()
     )
+
 }
 
 public class CreateCalendarEventRequestBuilder: RequestBuilder<CreateCalendarEventRequest> {
     public var name: String by required()
     public var durationInMinutes: Int = 60
-
     public var duration: Duration
         get() = durationInMinutes.minutes
         set(value) { durationInMinutes = value.inWholeMinutes.coerceAtMost(Int.MAX_VALUE.toLong() - 1).toInt() }
 
     public var description: String? = null
+
     public var location: String? = null
     public var url: String? = null
-
     public var startsAt: Instant? = null
 
     public var color: Int? = null
@@ -160,6 +157,7 @@ public class CreateCalendarEventRequestBuilder: RequestBuilder<CreateCalendarEve
         duration = duration.inWholeMinutes.toInt(),
         isPrivate = isPrivate
     )
+
 }
 
 public class UpdateCalendarEventRequestBuilder: RequestBuilder<UpdateCalendarEventRequest> {
@@ -167,12 +165,11 @@ public class UpdateCalendarEventRequestBuilder: RequestBuilder<UpdateCalendarEve
     public var description: String? = null
     public var location: String? = null
     public var url: String? = null
-
     public var startsAt: Instant? = null
 
     public var color: Int? = null
-    public var durationInMinutes: Int? = null
 
+    public var durationInMinutes: Int? = null
     public var duration: Duration?
         get() = durationInMinutes?.minutes
         set(value) { durationInMinutes = value?.inWholeMinutes?.coerceAtMost(Int.MAX_VALUE.toLong() - 1)?.toInt() }
@@ -189,4 +186,15 @@ public class UpdateCalendarEventRequestBuilder: RequestBuilder<UpdateCalendarEve
         duration = durationInMinutes.nullableOptional(),
         isPrivate = isPrivate
     )
+
+}
+
+private fun formatAndSerializeEmbed(embed: Embed): RawEmbed {
+    val serialized = embed.toSerializable()
+    val fieldList = serialized.fields.asNullable()
+    return when {
+        fieldList == null -> serialized
+        fieldList.isEmpty() -> serialized.copy(fields = OptionalProperty.NotPresent)
+        else -> serialized
+    }
 }

--- a/deck-rest/src/main/kotlin/io/github/deck/rest/builder/ChannelBuilders.kt
+++ b/deck-rest/src/main/kotlin/io/github/deck/rest/builder/ChannelBuilders.kt
@@ -2,9 +2,11 @@ package io.github.deck.rest.builder
 
 import io.github.deck.common.Embed
 import io.github.deck.common.EmbedBuilder
-import io.github.deck.common.entity.RawEmbed
 import io.github.deck.common.entity.RawServerChannelType
-import io.github.deck.common.util.*
+import io.github.deck.common.util.GenericId
+import io.github.deck.common.util.IntGenericId
+import io.github.deck.common.util.nullableOptional
+import io.github.deck.common.util.optional
 import io.github.deck.rest.request.*
 import io.github.deck.rest.util.required
 import kotlinx.datetime.Instant
@@ -19,14 +21,15 @@ import kotlin.time.Duration.Companion.minutes
 public class CreateChannelRequestBuilder: RequestBuilder<CreateChannelRequest> {
     public var name: String by required()
     public var topic: String? = null
-    public var type: RawServerChannelType by required()
 
+    public var type: RawServerChannelType by required()
     public var isPublic: Boolean = false
+
     // You must choose at least one of those to provide
     public var serverId: GenericId? = null
-
     public var groupId: GenericId? = null
     public var categoryId: IntGenericId? = null
+
     override fun toRequest(): CreateChannelRequest = CreateChannelRequest(
         name = name.optional(),
         topic = topic.nullableOptional(),
@@ -36,22 +39,22 @@ public class CreateChannelRequestBuilder: RequestBuilder<CreateChannelRequest> {
         groupId = groupId.nullableOptional(),
         categoryId = categoryId.nullableOptional()
     )
-
 }
 
 public class SendMessageRequestBuilder: RequestBuilder<SendMessageRequest> {
     public var isPrivate: Boolean = false
     public val repliesTo: MutableList<UUID> = mutableListOf()
+
     public var content: String?
         set(value) {
             contentElement = if (value == null) null else JsonPrimitive(value)
         }
         get() = contentElement?.jsonPrimitive?.content
-
     public var contentElement: JsonElement? = null
-    public var embeds: List<Embed> = listOf()
 
+    public var embeds: List<Embed> = listOf()
     public val silent: Boolean = false
+
     public fun replyTo(vararg messageIds: UUID): Unit =
         repliesTo.addAll(messageIds).let {}
 
@@ -61,12 +64,11 @@ public class SendMessageRequestBuilder: RequestBuilder<SendMessageRequest> {
 
     override fun toRequest(): SendMessageRequest = SendMessageRequest(
         content = contentElement,
-        embeds = embeds.map { formatAndSerializeEmbed(it) },
+        embeds = embeds.map { it.toSerializable() },
         isPrivate = isPrivate,
         isSilent = silent,
         replyMessageIds = repliesTo
     )
-
 }
 
 public class UpdateMessageRequestBuilder: RequestBuilder<UpdateMessageRequest> {
@@ -77,35 +79,35 @@ public class UpdateMessageRequestBuilder: RequestBuilder<UpdateMessageRequest> {
         get() = contentElement?.jsonPrimitive?.content
     public var contentElement: JsonElement? = null
     public var embeds: List<Embed> = listOf()
+
     public fun embed(builder: EmbedBuilder.() -> Unit) {
         embeds = embeds + EmbedBuilder().apply(builder).build()
     }
 
     override fun toRequest(): UpdateMessageRequest = UpdateMessageRequest(
         content = contentElement,
-        embeds = embeds.map { formatAndSerializeEmbed(it) },
+        embeds = embeds.map { it.toSerializable() },
     )
-
 }
 
 public class CreateDocumentationRequestBuilder: RequestBuilder<CreateDocumentationRequest> {
     public var title: String by required()
     public var content: String by required()
+
     override fun toRequest(): CreateDocumentationRequest = CreateDocumentationRequest(
         title = title,
         content = content
     )
-
 }
 
 public class CreateListItemRequestBuilder: RequestBuilder<CreateListItemRequest> {
     public var label: String by required()
     public var note: String? = null
+
     override fun toRequest(): CreateListItemRequest = CreateListItemRequest(
         message = label,
         note = note?.let { JsonObject(mapOf("content" to JsonPrimitive(note))) }.nullableOptional()
     )
-
 }
 
 public typealias UpdateListItemRequestBuilder = CreateListItemRequestBuilder
@@ -113,34 +115,35 @@ public typealias UpdateListItemRequestBuilder = CreateListItemRequestBuilder
 public class CreateForumTopicRequestBuilder: RequestBuilder<CreateForumTopicRequest> {
     public var title: String by required()
     public var content: String by required()
+
     override fun toRequest(): CreateForumTopicRequest = CreateForumTopicRequest(
         title = title,
         content = content
     )
-
 }
 
 public class UpdateForumTopicRequestBuilder: RequestBuilder<UpdateForumTopicRequest> {
     public var title: String? = null
     public var content: String? = null
+
     override fun toRequest(): UpdateForumTopicRequest = UpdateForumTopicRequest(
         title = title.nullableOptional(),
         content = content.nullableOptional()
     )
-
 }
 
 public class CreateCalendarEventRequestBuilder: RequestBuilder<CreateCalendarEventRequest> {
     public var name: String by required()
     public var durationInMinutes: Int = 60
+
     public var duration: Duration
         get() = durationInMinutes.minutes
         set(value) { durationInMinutes = value.inWholeMinutes.coerceAtMost(Int.MAX_VALUE.toLong() - 1).toInt() }
 
     public var description: String? = null
-
     public var location: String? = null
     public var url: String? = null
+
     public var startsAt: Instant? = null
 
     public var color: Int? = null
@@ -157,7 +160,6 @@ public class CreateCalendarEventRequestBuilder: RequestBuilder<CreateCalendarEve
         duration = duration.inWholeMinutes.toInt(),
         isPrivate = isPrivate
     )
-
 }
 
 public class UpdateCalendarEventRequestBuilder: RequestBuilder<UpdateCalendarEventRequest> {
@@ -165,11 +167,12 @@ public class UpdateCalendarEventRequestBuilder: RequestBuilder<UpdateCalendarEve
     public var description: String? = null
     public var location: String? = null
     public var url: String? = null
+
     public var startsAt: Instant? = null
 
     public var color: Int? = null
-
     public var durationInMinutes: Int? = null
+
     public var duration: Duration?
         get() = durationInMinutes?.minutes
         set(value) { durationInMinutes = value?.inWholeMinutes?.coerceAtMost(Int.MAX_VALUE.toLong() - 1)?.toInt() }
@@ -186,15 +189,4 @@ public class UpdateCalendarEventRequestBuilder: RequestBuilder<UpdateCalendarEve
         duration = durationInMinutes.nullableOptional(),
         isPrivate = isPrivate
     )
-
-}
-
-private fun formatAndSerializeEmbed(embed: Embed): RawEmbed {
-    val serialized = embed.toSerializable()
-    val fieldList = serialized.fields.asNullable()
-    return when {
-        fieldList == null -> serialized
-        fieldList.isEmpty() -> serialized.copy(fields = OptionalProperty.NotPresent)
-        else -> serialized
-    }
 }


### PR DESCRIPTION
Creating an embed with the message builder results, in the raw embed always having an empty array of fields instead of null in its final payload, which adds unnecessary spacing at the end of the embed if no fields are specified.

This image shows how it should look based on the code vs how it actually looks.
![guilded_image_f9fc0637776c5648ca66ec23a9619145](https://user-images.githubusercontent.com/38019186/182264975-6660a50e-e055-45fe-9364-5624a3e8e7aa.png)

To solve this issue, is just check the array length of the serialized embed and replace it with null incase the array is empty.